### PR TITLE
Limit setting properties on disposed objects to function values

### DIFF
--- a/closure/goog/disposable/disposable.js
+++ b/closure/goog/disposable/disposable.js
@@ -228,8 +228,10 @@ goog.Disposable.prototype.dispose = function() {
             throw new Error(
                 'Cannot access member ' + key + ' of disposed object');
           },
-          set: function() {
-            throw new Error('Cannot set member ' + key + ' of disposed object');
+          set: function(value) {
+            if (!goog.isFunction(value)) {
+                throw new Error('Cannot set member ' + key + ' of disposed object');
+            }
           }
         });
       }


### PR DESCRIPTION
This addresses a compatibility with the Jasmine testing framework.
Jasmine will restore a disposable object's spied-on functions after the
object has been disposed, thus throwing an error under the current
implementation.