### PR TITLE
Prevent registered disposables throwing on cleanup

### DIFF
--- a/closure/goog/disposable/disposable.js
+++ b/closure/goog/disposable/disposable.js
@@ -351,7 +351,8 @@ goog.Disposable.prototype.disposeInternal = function() {
   }
   if (this.registeredDisposables_) {
     while (this.registeredDisposables_.length) {
-      this.registeredDisposables_.shift().dispose();
+      const disposable = this.registeredDisposables_.shift();
+      disposable.isDisposed() || disposable.dispose();
     }
   }
 };


### PR DESCRIPTION
When using a component which extends `PropertyBinder` and utilized `new LucidEventTarget(this)`, the event target disposable was getting disposed of during the test on the destruction of the component, and the component was then trying to dispose of the event target **again** in this method. This fix prevents already disposed of registered disposables from attempting to dispose of twice.