### PR TITLE
Whitelist calling `dispose()` after item disposal

### DIFF
--- a/closure/goog/disposable/disposable.js
+++ b/closure/goog/disposable/disposable.js
@@ -215,10 +215,11 @@ goog.Disposable.prototype.dispose = function() {
     // causes this to fail.
     if (goog.DEBUG && !COMPILED) {
       // The only thing a disposed object can do is return true from
-      // isDisposed().
+      // isDisposed() or a harmless `dispose()` call.
       let whitelist = {
         isDisposed: 1,
         disposed_: 1,
+        dispose: 1,
       };
 
       // Keep a reference to the old values, so we can determine what object is


### PR DESCRIPTION
Before, we would receive thrown errors in the application because item disposals were very strict, and you couldn't call a harmless `dispose()` more than once on an item. This meant that in situations where the cleanup attempted more than one disposal, like in the case of complex, multi-listeners, or a disposable just registered more than once, then the disposal would throw an error only in uncompiled mode. These extra `dispose()` calls are harmless and ignored in compiled mode, so this change will make working with disposables a little more forgiving in uncompiled mode, with minimal to no run-time cost.